### PR TITLE
feature: add support for setting consensus signer private key by env or commandline parameter

### DIFF
--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -343,7 +343,7 @@ where
     async fn build_consensus(self, ctx: &BuilderContext<Node>) -> eyre::Result<Self::Consensus> {
         if ctx.is_dev() {
             // Ok(Arc::new(AutoSealConsensus::new(ctx.chain_spec())))
-            Ok(Arc::new(APos::new(ctx.provider().clone(), ctx.chain_spec())))
+            Ok(Arc::new(APos::new(ctx.provider().clone(), ctx.chain_spec(), ctx.config().dev.consensus_signer_private_key.to_string())))
         } else {
             Ok(Arc::new(EthBeaconConsensus::new(ctx.chain_spec())))
         }

--- a/crates/n42/clique/src/apos.rs
+++ b/crates/n42/clique/src/apos.rs
@@ -190,13 +190,14 @@ where
     pub fn new(
         provider: Provider,
         chain_spec: Arc<ChainSpec>,
+        signer_private_key: String,
     ) -> Self
     {
         let recents = RwLock::new(schnellru::LruMap::new(schnellru::ByLength::new(INMEMORY_SNAPSHOTS)));
         let signatures = schnellru::LruMap::new(schnellru::ByLength::new(INMEMORY_SIGNATURES));
 
         // signer_pk.sign_hash_sync();
-        let eth_signer: PrivateKeySigner = "".parse().unwrap();
+        let eth_signer: PrivateKeySigner = signer_private_key.parse().unwrap();
         //let eth_signer = PrivateKeySigner::random();
 
         info!(target: "consensus::apos", "apos set signer address {}", eth_signer.address());

--- a/crates/n42/n42-testing/src/dev.rs
+++ b/crates/n42/n42-testing/src/dev.rs
@@ -11,7 +11,7 @@ use zerocopy::AsBytes;
 use reth_chainspec::ChainSpec;
 use reth_provider::{BlockReaderIdExt, BlockNumReader};
 use crate::utils::n42_payload_attributes;
-use alloy_primitives::{Bytes, Address};
+use alloy_primitives::{Bytes, Address, B256};
 use alloy_genesis::CliqueConfig;
 use futures::StreamExt;
 use reth:: args::{DevArgs, DiscoveryArgs, NetworkArgs, RpcServerArgs};
@@ -162,7 +162,7 @@ impl CliqueTest {
                 .with_network(network_config.clone())
                 .with_unused_ports()
                 .with_rpc(RpcServerArgs::default().with_unused_ports().with_http())
-            .with_dev(DevArgs { dev: true, ..Default::default() });
+            .with_dev(DevArgs { dev: true, consensus_signer_private_key: B256::random(), ..Default::default() });
 
         let NodeHandle { node, .. } = NodeBuilder::new(node_config.clone())
             .testing_node(exec.clone())

--- a/crates/node/core/Cargo.toml
+++ b/crates/node/core/Cargo.toml
@@ -42,7 +42,7 @@ alloy-eips.workspace = true
 
 # misc
 eyre.workspace = true
-clap = { workspace = true, features = ["derive"] }
+clap = { workspace = true, features = ["derive", "env"] }
 humantime.workspace = true
 const_format.workspace = true
 rand.workspace = true


### PR DESCRIPTION
```shell
export CONSENSUS_SIGNER_PRIVATE_KEY=0000000000000000000000000000000000000000000000000000000000000002

cargo run node --chain n42 --dev --dev.consensus-signer-private-key 0000000000000000000000000000000000000000000000000000000000000002
```