### PR TITLE
feature: add consensus admin rpc such as propose, discard, etc

### DIFF
--- a/bin/n42/Cargo.toml
+++ b/bin/n42/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 #n42
 num_cpus = "1.16.0"
 n42-engine-types.workspace = true
+n42-primitives.workspace = true
 # reth
 reth-cli.workspace = true
 reth-ethereum-cli.workspace = true
@@ -97,6 +98,8 @@ eyre.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 backon.workspace = true
 similar-asserts.workspace = true
+
+jsonrpsee = { workspace = true, features = ["server", "macros"] }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/bin/n42/src/cli/mod.rs
+++ b/bin/n42/src/cli/mod.rs
@@ -242,7 +242,7 @@ pub enum Commands<C: ChainSpecParser, Ext: clap::Args + fmt::Debug> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::args::ColorMode;
+    use reth_node_core::args::ColorMode;
     use clap::CommandFactory;
     use reth_ethereum_cli::chainspec::SUPPORTED_CHAINS;
 

--- a/bin/n42/src/main.rs
+++ b/bin/n42/src/main.rs
@@ -3,6 +3,8 @@
 #[global_allocator]
 static ALLOC: reth_cli_util::allocator::Allocator = reth_cli_util::allocator::new_allocator();
 
+use std::collections::HashMap;
+
 use clap::{Args, Parser};
 use n42::cli::Cli;
 use reth_ethereum_cli::chainspec::EthereumChainSpecParser;
@@ -15,6 +17,12 @@ use reth_tracing::tracing::warn;
 use tracing::info;
 
 use n42_engine_types::{N42Node, N42NodeAddOns};
+
+use jsonrpsee::{core::RpcResult, proc_macros::rpc, types::{error::INVALID_PARAMS_CODE, ErrorObject}};
+use alloy_primitives::Address;
+use reth_consensus::Consensus;
+use n42_primitives::Snapshot;
+use reth_provider::HeaderProvider;
 
 /// Parameters for configuring the engine
 #[derive(Debug, Clone, Args, PartialEq, Eq)]
@@ -51,6 +59,78 @@ impl Default for EngineArgs {
     }
 }
 
+/// trait interface for a custom rpc namespace: `consensus`
+///
+/// This defines an additional namespace where all methods are configured as trait functions.
+#[cfg_attr(not(test), rpc(server, namespace = "consensusExt"))]
+#[cfg_attr(test, rpc(server, client, namespace = "consensusExt"))]
+pub trait ConsensusExtApi {
+    /// Propose in the clique consensus.
+    #[method(name = "propose")]
+    fn propose(&self,
+        address: Address,
+        auth: bool,
+        ) -> RpcResult<()>;
+
+    /// Discard in the clique consensus.
+    #[method(name = "discard")]
+    fn discard(
+        &self,
+        address: Address,
+        ) -> RpcResult<()>;
+
+    /// GetSnapshot in the clique consensus.
+    #[method(name = "get_snapshot")]
+    fn get_snapshot(
+        &self,
+        number: u64,
+        ) -> RpcResult<Snapshot>;
+
+    /// Proposals in the clique consensus.
+    #[method(name = "proposals")]
+    fn proposals(
+        &self,
+        ) -> RpcResult<HashMap<Address, bool>>;
+}
+
+/// The type that implements the `consensus` rpc namespace trait
+pub struct ConsensusExt<Cons, Provider> {
+    consensus: Cons,
+    provider: Provider,
+}
+
+impl<Cons, Provider> ConsensusExtApiServer for ConsensusExt<Cons, Provider>
+where
+    Cons: Consensus + Clone + 'static,
+    Provider: HeaderProvider + Clone + 'static,
+{
+    fn propose(&self,
+        address: Address,
+        auth: bool,
+        ) -> RpcResult<()> {
+        Ok(self.consensus.propose(address, auth).unwrap_or_default())
+    }
+
+    fn discard(&self,
+        address: Address,
+        ) -> RpcResult<()> {
+        Ok(self.consensus.discard(address).unwrap_or_default())
+    }
+
+    fn get_snapshot(&self,
+        number: u64,
+        ) -> RpcResult<Snapshot> {
+        let hash = self.provider.header_by_number(number).unwrap_or_default().unwrap_or_default().hash_slow();
+        self.consensus.snapshot(number, hash, None).map_err(|err| ErrorObject::owned(INVALID_PARAMS_CODE, err.to_string(), Option::<()>::None))
+    }
+
+    fn proposals(
+        &self,
+        ) -> RpcResult<HashMap<Address, bool>> {
+        Ok(self.consensus.proposals().unwrap_or_default())
+    }
+}
+
 fn main() {
     reth_cli_util::sigsegv_handler::install();
 
@@ -75,6 +155,20 @@ fn main() {
                         .with_types_and_provider::<N42Node, BlockchainProvider2<_>>()
                         .with_components(N42Node::components())
                         .with_add_ons(N42NodeAddOns::default())
+                        .extend_rpc_modules(|ctx| {
+
+                            let consensus = ctx.consensus().clone();
+                            let provider = ctx.provider().clone();
+
+                            let ext = ConsensusExt { consensus, provider };
+
+                            // now we merge our extension namespace into all configured transports
+                            ctx.modules.merge_configured(ext.into_rpc())?;
+
+                            println!("consensus rpc extension enabled");
+
+                            Ok(())
+                        })
                         .launch_with_fn(|builder| {
                             let launcher = EngineNodeLauncher::new(
                                 builder.task_executor().clone(),
@@ -103,6 +197,9 @@ fn main() {
 mod tests {
     use super::*;
     use clap::Parser;
+    use jsonrpsee::{http_client::HttpClientBuilder, server::ServerBuilder};
+    use reth_consensus::noop::NoopConsensus;
+    use reth_provider::test_utils::NoopProvider;
 
     /// A helper type to parse Args more easily
     #[derive(Parser)]
@@ -116,5 +213,54 @@ mod tests {
         let default_args = EngineArgs::default();
         let args = CommandParser::<EngineArgs>::parse_from(["reth"]).args;
         assert_eq!(args, default_args);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_call_propose_http() {
+        let server_addr = start_server().await;
+        let uri = format!("http://{}", server_addr);
+        let client = HttpClientBuilder::default().build(&uri).unwrap();
+        let result = ConsensusExtApiClient::propose(&client, Address::random(), true).await.unwrap();
+        assert_eq!(result, ());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_call_discard_http() {
+        let server_addr = start_server().await;
+        let uri = format!("http://{}", server_addr);
+        let client = HttpClientBuilder::default().build(&uri).unwrap();
+        let result = ConsensusExtApiClient::discard(&client, Address::random()).await.unwrap();
+        assert_eq!(result, ());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_call_get_snapshot_http() {
+        let server_addr = start_server().await;
+        let uri = format!("http://{}", server_addr);
+        let client = HttpClientBuilder::default().build(&uri).unwrap();
+        let result = ConsensusExtApiClient::get_snapshot(&client, 0).await.unwrap();
+        assert_eq!(result, Snapshot::default());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_call_proposals_http() {
+        let server_addr = start_server().await;
+        let uri = format!("http://{}", server_addr);
+        let client = HttpClientBuilder::default().build(&uri).unwrap();
+        let result = ConsensusExtApiClient::proposals(&client).await.unwrap();
+        assert_eq!(result, HashMap::default());
+    }
+
+    async fn start_server() -> std::net::SocketAddr {
+        let server = ServerBuilder::default().build("127.0.0.1:0").await.unwrap();
+        let addr = server.local_addr().unwrap();
+        let consensus = NoopConsensus::default();
+        let provider = NoopProvider::default();
+        let api = ConsensusExt { consensus, provider };
+        let server_handle = server.start(api.into_rpc());
+
+        tokio::spawn(server_handle.stopped());
+
+        addr
     }
 }

--- a/crates/consensus/consensus/src/lib.rs
+++ b/crates/consensus/consensus/src/lib.rs
@@ -19,6 +19,7 @@ use reth_primitives::{
     InvalidTransactionError, Receipt, SealedBlock, SealedHeader,
 };
 use n42_primitives::Snapshot;
+use std::collections::HashMap;
 
 /// A consensus implementation that does nothing.
 pub mod noop;
@@ -167,6 +168,12 @@ pub trait Consensus: Debug + Send + Sync {
         address: Address,
     ) -> Result<(), ConsensusError> {
         Ok(())
+    }
+
+    fn proposals(
+        &self,
+    ) -> Result<HashMap<Address, bool>, ConsensusError> {
+        Ok(HashMap::new())
     }
 }
 

--- a/crates/n42/clique/src/apos.rs
+++ b/crates/n42/clique/src/apos.rs
@@ -895,6 +895,7 @@ where
         address: Address,
         auth: bool,
     ) -> Result<(), ConsensusError> {
+        info!(target: "consensus::apos", "propose(), address={}, auth={}", address, auth);
         let mut proposals_guard = self.proposals.write().unwrap();
         proposals_guard.insert(address, auth);
         Ok(())
@@ -904,8 +905,17 @@ where
         &self,
         address: Address,
     ) -> Result<(), ConsensusError> {
+        info!(target: "consensus::apos", "discard(), address={}", address);
         let mut proposals_guard = self.proposals.write().unwrap();
         proposals_guard.remove(&address);
         Ok(())
+    }
+
+    fn proposals(
+        &self,
+    ) -> Result<HashMap<Address, bool>, ConsensusError> {
+        info!(target: "consensus::apos", "proposals()");
+        let mut proposals_guard = self.proposals.read().unwrap();
+        Ok(proposals_guard.clone())
     }
 }

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -299,6 +299,11 @@ where
     ) -> &PayloadBuilderHandle<<Node::Types as NodeTypesWithEngine>::Engine> {
         self.node.payload_builder()
     }
+
+    /// Returns the handle to the consensus
+    pub fn consensus(&self) -> &Node::Consensus {
+        self.node.consensus()
+    }
 }
 
 /// Handle to the launched RPC servers.


### PR DESCRIPTION
Unit tests:
```shell
cargo test -p n42 test_call_propose_http
cargo test -p n42 test_call_discard_http
cargo test -p n42 test_call_proposals_http
cargo test -p n42 test_call_get_snapshot_http
```

E2e tests:
```shell
cargo run node --chain n42 --dev --dev.block-time 8s -vvvv --http
--http.api "admin,debug,eth,net,trace,txpool,web3,rpc"
```

```shell
$ cast rpc consensusExt_proposals

{}

$ cast rpc consensusExt_propose ad52a9f149b1b87eb5ca4268842d463696a7f459 true

null

$ cast rpc consensusExt_proposals

{"0xad52a9f149b1b87eb5ca4268842d463696a7f459":true}

$ cast rpc consensusExt_discard ad52a9f149b1b87eb5ca4268842d463696a7f459

null

$ cast rpc consensusExt_proposals

{}

$ cast rpc consensusExt_get_snapshot 1948

{"config":{"period":8,"epoch":3000,"reward_epoch":10800,"reward_limit":
"0x6f05b59d3b20000","deposit_contract":
"0x0000000000000000000000000000000000000000"},"number":1948,"hash":
"0x786118a527545da6ae012a0a7dc2095a32dd5788151fca29ca9946c1a5582d97","signers":
["0xe08895ee8a45190c192652890a64b6a92045c2ac",
"0xad52a9f149b1b87eb5ca4268842d463696a7f459"],"recents":{"1948":
"0xe08895ee8a45190c192652890a64b6a92045c2ac"},"votes":[],"tally":{}}

```

auth rpc example:
```shell
$ export
JWT_SECRET=0000000000000000000000000000000000000000000000000000000000000002

$ cargo run node --chain n42 --dev --dev.block-time 8s -vvvv --http --http.api
"admin,debug,eth,net,trace,txpool,web3,rpc" --rpc.jwtsecret $JWT_SECRET

$ cast rpc consensusExt_proposals --jwt-secret $JWT_SECRET

{}
```