### PR TITLE
fix: fix block gas limit bug

### DIFF
--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -45,7 +45,7 @@ pub static N42: LazyLock<Arc<ChainSpec>> = LazyLock::new(|| {
         hardforks: EthereumHardfork::n42().into(),
         deposit_contract: None,
         base_fee_params: Default::default(),
-        max_gas_limit: 0,
+        max_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT,
         prune_delete_limit: 0,
     };
     spec.genesis.config.dao_fork_support = true;


### PR DESCRIPTION
```buglog
curl --location '127.0.0.1:8545' \
> --header 'Content-Type: application/json' \
> > --data
'{
>         "jsonrpc":"2.0",
>         "method":"eth_sendRawTransaction",
>         "params":
>
["0xf865018504a817c80082520894e08895ee8a45190c192652890a64b6a92045c2ac808081dfa03f346e2d3b2852d91ac7ce362f2a7200cd1a43e3a4bafc587a7d7c5daca210eda0329ae949f236919e6ef5ec8b170b05d2191993867a5d73ce20b146257ab20d90"],
>         "id":1
> }'
{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"exceeds block
gas
limit"}}
```