### PR TITLE
Fix README.md badges and add proper shield.io references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # Rust Blockchain Project
 
-![Rust](https://img.shields.io/badge/rust-v1.5%2B-orange)
-![License](https://img.shields.io/github/license/n42/rust-blockchain)
-![Build Status](https://img.shields.io/github/workflow/status/n42/rust-blockchain/CI)
+[![Rust](https://img.shields.io/badge/rust-1.50%2B-orange.svg)](https://www.rust-lang.org)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/n42blockchain/N42-rs/ci.yml?branch=main)](https://github.com/n42blockchain/N42-rs/actions)
+[![GitHub License](https://img.shields.io/github/license/n42blockchain/N42-rs)](https://github.com/n42blockchain/N42-rs/blob/main/LICENSE)
+[![GitHub Issues](https://img.shields.io/github/issues/n42blockchain/N42-rs)](https://github.com/n42blockchain/N42-rs/issues)
+[![GitHub Pull Requests](https://img.shields.io/github/issues-pr/n42blockchain/N42-rs)](https://github.com/n42blockchain/N42-rs/pulls)
+[![GitHub Stars](https://img.shields.io/github/stars/n42blockchain/N42-rs)](https://github.com/n42blockchain/N42-rs/stargazers)
+[![GitHub Forks](https://img.shields.io/github/forks/n42blockchain/N42-rs)](https://github.com/n42blockchain/N42-rs/network/members)
 
 ## Introduction
 


### PR DESCRIPTION
This PR updates the broken badges in the README.md file to properly reference the n42blockchain/N42-rs repository. The changes include:

1. Adding proper shield.io badges with correct repository references
2. Adding badges for Rust version, GitHub workflow status, license, issues, and pull requests
3. Ensuring all badge links are functional and accurately reflect repository status
